### PR TITLE
Add device data and creation endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,7 +24,7 @@ from models.user import User as UserModel
 
 from resources.user import AuthorizeUser, AuthorizedUser, UserInfo, Login, User
 from resources.user import Logout
-from resources.device import Device
+from resources.device import DeviceCollectionResource, DeviceResource
 from resources.system import System
 
 from auth import google, initialize_tokengetter, read_client_keys
@@ -54,8 +54,13 @@ app.add_url_rule('/api/login', view_func=Login.as_view('login'))
 app.add_url_rule('/api/logout', view_func=Logout.as_view('logout'))
 
 app.add_url_rule('/api/system', view_func=System.as_view('system'))
-app.add_url_rule('/api/device', view_func=Device.as_view('device'))
 
+app.add_url_rule('/api/device', view_func=DeviceCollectionResource.as_view('device'),
+                 methods=["POST"])
+
+single_dev_view = DeviceResource.as_view('device.single')
+app.add_url_rule('/api/device/data', view_func=single_dev_view,
+                 methods=["POST"])
 auth = google.initialize(app)
 initialize_tokengetter(auth)
 

--- a/backend/models/device.py
+++ b/backend/models/device.py
@@ -4,9 +4,20 @@ from google.appengine.ext import ndb
 class Device(ndb.Model):
     serial_num = ndb.StringProperty()
     system_key = ndb.KeyProperty(kind="System")
-    name = ndb.StringProperty()
+    name = ndb.StringProperty(default="Default Device")
     is_connected = ndb.BooleanProperty()
     device_type_key = ndb.IntegerProperty()
+
+    @classmethod
+    def create(cls, serial_number):
+        """
+        Create a new unassociated device in the datastore.
+        :param serial_number: Device serial number
+        :return:
+        """
+        return cls(
+            serial_num=serial_number
+        )
 
     @classmethod
     def from_serial_number(cls, serial_number):
@@ -27,7 +38,10 @@ class Device(ndb.Model):
 
     def to_json(self):
         device_dict = self.to_dict(exclude=['system_key', 'device_type_key'])
-        device_dict['system_id'] = self.system_key.integer_id()
+        if self.system_key:
+            device_dict['system_id'] = self.system_key.integer_id()
+        else:
+            device_dict['system_id'] = None
         return device_dict
 
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -17,6 +17,8 @@ class User(ndb.Model, UserMixin):
     lname = ndb.StringProperty()
     phone_num = ndb.IntegerProperty()
 
+    is_admin = ndb.BooleanProperty(default=False)
+
     oauth_id = ndb.StringProperty(required=True)
     create_date = ndb.DateTimeProperty(auto_now_add=True)
 

--- a/backend/resources/device.py
+++ b/backend/resources/device.py
@@ -1,5 +1,6 @@
 from flask import abort, request, jsonify
 from flask.views import MethodView
+from flask_login import login_required, current_user
 
 from models.device import Device as DeviceModel
 from models.device import DeviceData
@@ -7,7 +8,23 @@ from models.device import DeviceData
 from storage import store_data
 
 
-class Device(MethodView):
+class DeviceCollectionResource(MethodView):
+    @login_required
+    def post(self):
+        if not current_user.is_admin:
+            abort(401)
+
+        data = request.get_json()
+        serial_number = data.get("serial_number")
+        if serial_number is None:
+            abort(400)
+
+        device = DeviceModel.create(serial_number)
+        device.put()
+        return jsonify(device.to_json())
+
+
+class DeviceResource(MethodView):
     def post(self):
         # Request post json data
         data = request.get_json()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -73,6 +73,7 @@ def random_device(random_system):
     yield dev
     dev.key.delete()
 
+
 @pytest.fixture
 def random_devicedata():
     data = DeviceData(
@@ -82,10 +83,18 @@ def random_devicedata():
     yield data
     data.key.delete()
 
+
 @pytest.fixture
 def logged_in_app(app, random_user):
     with app.session_transaction() as sess:
         sess['user_id'] = random_user.oauth_id
         sess['_fresh'] = True
     return app
+
+
+@pytest.fixture
+def admin_app(logged_in_app, random_user):
+    random_user.is_admin = True
+    random_user.put()
+    return logged_in_app
 

--- a/backend/tests/test_resources/test_device.py
+++ b/backend/tests/test_resources/test_device.py
@@ -1,4 +1,6 @@
 import json
+import uuid
+
 import pytest
 
 
@@ -12,7 +14,7 @@ def device_test_data(random_device):
 
 def test_device_post(app, random_device, device_test_data):
     with app:
-        resp = app.post('/api/device', data=json.dumps(device_test_data),
+        resp = app.post('/api/device/data', data=json.dumps(device_test_data),
                         headers={'content-type': 'application/json'})
 
     assert resp.status_code == 200
@@ -24,7 +26,7 @@ def test_device_post(app, random_device, device_test_data):
 
 def test_device_post_nocontenttype(app, random_device, device_test_data):
     with app:
-        resp = app.post('/api/device', data=json.dumps(device_test_data))
+        resp = app.post('/api/device/data', data=json.dumps(device_test_data))
 
     assert resp.status_code == 400
 
@@ -34,7 +36,23 @@ def test_device_post_nocontenttype(app, random_device, device_test_data):
 
 def test_malformed_data(app):
     with app:
-        resp = app.post('/api/device', data="{}",
+        resp = app.post('/api/device/data', data="{}",
                         headers={"content-type": "application/json"})
 
     assert resp.status_code == 400
+
+
+def test_device_creation(admin_app):
+    serial_number = str(uuid.uuid4())
+    post_data = {
+        "serial_number": serial_number
+    }
+
+    with admin_app:
+        resp = admin_app.post('/api/device', data=json.dumps(post_data),
+                              headers={"content-type": "application/json"})
+
+    assert resp.status_code == 200
+
+    from models.device import Device
+    assert Device.from_serial_number(serial_number) is not None


### PR DESCRIPTION
@JAKeeney the data endpoint has changed to `/api/device/data`

This adds a `/api/device` endpoint that allows us to create devices.