### PR TITLE
Fix how storage works, implement DeviceDataType use

### DIFF
--- a/backend/models/device.py
+++ b/backend/models/device.py
@@ -112,9 +112,20 @@ class DeviceData(ndb.Model):
 
 class DeviceDataType(ndb.Model):
     type_name = ndb.StringProperty()
+    is_binary = ndb.BooleanProperty(required=True)
+
+    mime_type = ndb.StringProperty(required=True)
 
     def to_json(self):
-        data = {
-            "type_name": self.type_name
-        }
+        # type: () -> dict
+        data = self.to_dict()
         return data
+
+    @classmethod
+    def from_name(cls, type_name):
+        """
+        Gets Data Type object from the given name.
+        :param type_name:
+        :return: Datastore object or None
+        """
+        return cls.query(cls.type_name == type_name).get()

--- a/backend/storage/getter.py
+++ b/backend/storage/getter.py
@@ -1,3 +1,5 @@
+import os
+
 import cloudstorage as gcs
 from storage import BUCKET_PREFIX
 
@@ -5,8 +7,13 @@ from models.device import Device
 
 READ_RETRY = gcs.RetryParams(backoff_factor=1.1)
 
+# Path is gonna look like:
+# /devicedata/12345/0.json
+# /devicedata/12345/1.png
+
 
 def get_latest_data_location(device):
+    # type: (Device) -> str
     """
     Gets the url path to the latest data entry from a given device
     :param device: device datastore object
@@ -15,37 +22,45 @@ def get_latest_data_location(device):
     serial = device.serial_num
     base_path = BUCKET_PREFIX.format(serial)
 
-    last_info = None
+    filenames = []
 
+    # This is probably wrong too. Damnit.
     for statinfo in gcs.listbucket(base_path, retry_params=READ_RETRY):
-        last_info = statinfo
+        filenames.append(statinfo.filename)
+
+    split_filenames = [os.path.splitext(f) for f in filenames]
+
+    with_index = [(int(os.path.split(f[0])[1]), f) for f in split_filenames]
+    sorted_filenames = sorted(with_index, key=lambda e: e[0])
 
     try:
-        filename = last_info.filename
-    except AttributeError:
+        index, split_filename = sorted_filenames[0]
+    except IndexError:
         raise RuntimeError("There are no files in the storage.")
+
+    filename = split_filename[0] + split_filename[1]
 
     return filename
 
 
-def get_next_data_location(device, ext=None):
+def get_next_data_location(device):
     # type: (Device, str) -> str
     """
-    Gets an unused url for the next data entry from a given device.
+    Gets an unused url for the next data entry from a given device. WITHOUT EXTENSION.
     :param device: Device datastore object
-    :param ext:
     :return: string
     """
-    raise NotImplementedError("Need to use os.path manipulations here.")
 
     try:
         last = get_latest_data_location(device)
     except RuntimeError:
-        last = BUCKET_PREFIX.format(device.serial_num) + "/0"
-        num = -1
-    else:
-        num = int(last[-1])
+        last = BUCKET_PREFIX.format(device.serial_num) + "/-1"
+
+    filepath, ext = os.path.splitext(last)
+    head, tail = os.path.split(filepath)
+    num = int(tail)
 
     num += 1
 
-    return last[:-1] + str(num) + ".{}".format(ext) if ext else ""
+
+    return os.path.join(head, str(num))

--- a/backend/storage/getter.py
+++ b/backend/storage/getter.py
@@ -1,6 +1,8 @@
 import cloudstorage as gcs
 from storage import BUCKET_PREFIX
 
+from models.device import Device
+
 READ_RETRY = gcs.RetryParams(backoff_factor=1.1)
 
 
@@ -26,12 +28,16 @@ def get_latest_data_location(device):
     return filename
 
 
-def get_next_data_location(device):
+def get_next_data_location(device, ext=None):
+    # type: (Device, str) -> str
     """
     Gets an unused url for the next data entry from a given device.
     :param device: Device datastore object
+    :param ext:
     :return: string
     """
+    raise NotImplementedError("Need to use os.path manipulations here.")
+
     try:
         last = get_latest_data_location(device)
     except RuntimeError:
@@ -42,4 +48,4 @@ def get_next_data_location(device):
 
     num += 1
 
-    return last[:-1] + str(num)
+    return last[:-1] + str(num) + ".{}".format(ext) if ext else ""

--- a/backend/storage/writer.py
+++ b/backend/storage/writer.py
@@ -1,32 +1,43 @@
+import binascii
 import json
 
 import cloudstorage as gcs
-import base64
 from storage.getter import get_next_data_location
+
+from models.device import Device, DeviceDataType
 
 WRITE_RETRY = gcs.RetryParams(backoff_factor=1.1)
 
 
-def store_data(device, data):
+def store_data(device, data, type, extension):
+    # type: (Device, object, DeviceDataType, str) -> str
     """
     Stores data and returns the url to it.
     :param device: The device object from datastore
-    :param data: raw data from device, will be stored B64 encoded
-    :return: string
+    :param data: raw data from device, should be json or binary data
+    :param type: DeviceDataType object from datastore
+    :param extension: file extension for data - string
+    :return: string of location
     """
-    filename = get_next_data_location(device)
+    filename = get_next_data_location(device, ext=extension)
     dev_id = device.key.integer_id()
+
+    if type.is_binary:
+        mode = 'wb'
+        data = binascii.a2b_base64(data)
+    else:
+        mode = 'w'
+        data = json.dumps(data)
+
     gcs_file = gcs.open(filename=filename,
-                        mode='w',
-                        content_type='text/plain',  # This will need to be changed?
+                        mode=mode,
+                        content_type=type.mime_type,
                         options={
                             'x-goog-meta-devid': str(dev_id)
                         },
                         retry_params=WRITE_RETRY)
 
-    b64_data = base64.b64encode(json.dumps(data))
-
-    gcs_file.write(b64_data)
+    gcs_file.write(data)
 
     gcs_file.close()
 

--- a/backend/storage/writer.py
+++ b/backend/storage/writer.py
@@ -16,10 +16,10 @@ def store_data(device, data, type, extension):
     :param device: The device object from datastore
     :param data: raw data from device, should be json or binary data
     :param type: DeviceDataType object from datastore
-    :param extension: file extension for data - string
+    :param extension: file extension for data WITHOUT PERIOD - string
     :return: string of location
     """
-    filename = get_next_data_location(device, ext=extension)
+    filename = get_next_data_location(device) + "." + extension
     dev_id = device.key.integer_id()
 
     if type.is_binary:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,7 +5,7 @@ sys.path.insert(1, 'google_appengine')
 sys.path.insert(1, 'google_appengine/lib/yaml/lib')
 sys.path.insert(1, 'lib')
 
-from models.device import Device, DeviceData
+from models.device import Device, DeviceData, DeviceDataType
 from models.system import System
 from models.owner import Owner
 from models.secondary import Secondary
@@ -118,6 +118,18 @@ def random_devicedata():
     data.put()
     yield data
     data.key.delete()
+
+
+@pytest.fixture
+def datatype_json():
+    datatype = DeviceDataType(
+        type_name="json",
+        is_binary=False,
+        mime_type="application/json"
+    )
+    datatype.put()
+    yield datatype
+    datatype.key.delete()
 
 
 @pytest.fixture

--- a/backend/tests/test_resources/test_device.py
+++ b/backend/tests/test_resources/test_device.py
@@ -5,10 +5,12 @@ import pytest
 
 
 @pytest.fixture
-def device_test_data(random_device):
+def device_test_data(random_device, datatype_json):
     return dict(
         serial_number=random_device.serial_num,
-        data={}
+        data={},
+        type=datatype_json.type_name,
+        ext="json"
     )
 
 

--- a/backend/tests/test_storage/test_storage.py
+++ b/backend/tests/test_storage/test_storage.py
@@ -1,10 +1,12 @@
+import os
+
 import pytest
 
 
 @pytest.fixture
-def device_data_location(random_device):
+def device_data_location(random_device, datatype_json):
     from storage.writer import store_data
-    return store_data(random_device, {})
+    return store_data(random_device, {}, datatype_json, "json")
 
 
 def test_starting_location_no_files(random_device):
@@ -21,11 +23,17 @@ def test_last_location_no_files(random_device):
         get_latest_data_location(device=random_device)
 
 
-def test_with_files(random_device, device_data_location):
-    assert device_data_location.endswith("0")
+def test_with_files(random_device, device_data_location,
+                    datatype_json):
+    filepath, ext = os.path.splitext(device_data_location)
+    assert filepath.endswith("0")
 
     from storage.writer import store_data
-    next_location = store_data(random_device, {"hi": "world"})
+    next_location = store_data(random_device, {"hi": "world"},
+                               type=datatype_json,
+                               extension="json")
 
-    assert next_location.endswith("1")
+    filepath, ext = os.path.splitext(next_location)
+
+    assert filepath.endswith("1")
 


### PR DESCRIPTION
@JAKeeney THIS CHANGES HOW YOU SEND DATA TO THE BACKEND FROM THE PI. You are now required to send a `type` and `ext`(ension) keys with the original `serial_number` and `data`. The type MUST correspond to an existing `type_name` in a DeviceDataType Entity